### PR TITLE
Fix printing list of ints

### DIFF
--- a/prove_test.go
+++ b/prove_test.go
@@ -174,6 +174,15 @@ func TestAppend(t *testing.T) {
 	if x := proofs[0].ByName_("List").String(); x != "[a,b,c,d,e]" {
 		t.Errorf("Wrong solution: %s", x)
 	}
+
+	proofs = m.ProveAll(`append([65], [66,67], List).`)
+	if len(proofs) != 1 {
+		t.Errorf("Wrong number of answers: %d vs 1", len(proofs))
+	}
+	if x := proofs[0].ByName_("List").String(); x != "[65,66,67]" {
+		t.Errorf("Wrong solution: %s", x)
+	}
+
 }
 
 func TestCall(t *testing.T) {

--- a/term/compound.go
+++ b/term/compound.go
@@ -69,11 +69,11 @@ func (self *Compound) Arguments() []Term {
 	return self.Args
 }
 func (self *Compound) String() string {
-	if IsString(self) {
-		return PrettyString(self)
-	}
 	if IsList(self) {
 		return PrettyList(self)
+	}
+	if IsString(self) {
+		return PrettyString(self)
 	}
 	quotedFunctor := QuoteFunctor(self.Name())
 


### PR DESCRIPTION
There is an issue in printing list of ints, because `Compound`'s `String` method first checks if  term is a String and later if it's a List.
Unfortunately for list of ints, e.g. `[1, 2, 3]` the function 
`func IsString(t Term) bool` returns true, because it loops over ints unless we get an empty list:
```go
//...
		args := c.Arguments()
		if !IsInteger(args[0]) {
			return false
		}
		if IsCompound(args[1]) {
			c = args[1].(*Compound)
		} else if IsEmptyList(args[1]) {
			break
		} 
```

And of course printing the Compound `[1,2,3]` as a String gives us wrong result. 
For instance:
```prolog
append([65], [66,67], List).
```
gives `[ABC]`, instead of `[65,66,67]`.

Anyway, I'm not sure if this is 100% correct fix (maybe there is a more elegant way to do it), but so far it works fine if I replace in `func (self *Compound) String() string` an order of _if-checks_. First check if the term is a List and later if it's a String.
